### PR TITLE
Rake evaluate returns more information

### DIFF
--- a/lib/tasks/evaluate.rake
+++ b/lib/tasks/evaluate.rake
@@ -82,4 +82,6 @@ task :evaluate => :petrovich do
   total_size = total.values.inject(&:+)
   puts 'Well, the precision on %d examples is about %.4f%%.' %
     [total_size, (correct_size / total_size.to_f * 100)]
+
+  puts "\tTotal: %d\n\tCorrect: %d\n\tError: %d" % [total_size, correct_size, total_size - correct_size]
 end


### PR DESCRIPTION
Added the additional lines to output. It's necessary to simplify a comparison of rule sets
