### PR TITLE
Regexp matching + benchmark

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,4 +15,9 @@ task :petrovich do
   require 'petrovich'
 end
 
+Rake::TestTask.new(:bench) do |test|
+  test.libs << 'test'
+  test.test_files = Dir['test/**/bench_*.rb']
+end
+
 Dir.glob('lib/tasks/*.rake').each { |r| import r }

--- a/lib/petrovich/case/rule/test.rb
+++ b/lib/petrovich/case/rule/test.rb
@@ -6,12 +6,11 @@ module Petrovich
         attr_reader :suffix
 
         def initialize(suffix)
-          @suffix = Unicode.downcase(suffix)
+          @suffix = /#{suffix}$/i
         end
 
         def match?(name)
-          name = Unicode.downcase(name)
-          suffix == name.slice([name.size - suffix.size, 0].max..-1)
+          !!name.match(suffix)
         end
 
         def inspect

--- a/lib/petrovich/gender/rule.rb
+++ b/lib/petrovich/gender/rule.rb
@@ -8,14 +8,13 @@ module Petrovich
       def initialize(opts)
         @gender = opts[:gender]
         @as = opts[:as]
-        @suffix = opts[:suffix]
+        @suffix = /#{opts[:suffix]}$/i
       end
 
       def match?(name, match_as)
         return false unless match_as == as
 
-        name = Unicode.downcase(name)
-        @suffix == name.slice([name.size - @suffix.size, 0].max..-1)
+        !!name.match(suffix)
       end
     end
   end

--- a/test/bench_core.rb
+++ b/test/bench_core.rb
@@ -1,0 +1,40 @@
+require 'minitest/autorun'
+require 'minitest/benchmark'
+require 'petrovich'
+
+module MockBenchmark
+  module Settings
+    def bench_range
+      [20, 80, 320, 1280]
+    end
+
+    def run(*)
+      puts 'Running ' + self.name
+      super
+    end
+  end
+
+  def self.included(base)
+    base.extend Settings
+  end
+
+  def result_code
+    ''
+  end
+end
+
+class Petrovich::Benchmark < Minitest::Benchmark
+  include MockBenchmark
+
+  def bench_dative_to_s
+    assert_performance_linear 0.99 do |n|
+      n.times do
+        Petrovich(
+          lastname: 'Салтыков-Щедрин',
+          firstname: 'Михаил',
+          middlename: 'Евграфович',
+        ).dative.to_s
+      end
+    end
+  end
+end


### PR DESCRIPTION
1) Добавил простую проверку быстродействия (запускать `rake bench`)
2) Поменял странный код на регекспы

До изменений:

```
Running Petrovich::Benchmark
bench_dative_to_s        0.030225        0.139556        0.583870        2.535422
```

После изменений:

```
Running Petrovich::Benchmark
bench_dative_to_s        0.009378        0.038192        0.151915        0.607715
```

То есть, примерно в 4.5 раза быстрее.