### PR TITLE
use Regexp union instead of iterating Array of Regexps

### DIFF
--- a/lib/petrovich/case/rule.rb
+++ b/lib/petrovich/case/rule.rb
@@ -12,6 +12,8 @@ module Petrovich
         @tests        = opts[:tests]
         @tags         = []
 
+        @tests_regexp = Regexp.union(Array(@tests).map(&:suffix))
+
         assert_name_part!(@as)
       end
 
@@ -25,7 +27,7 @@ module Petrovich
         return false if gender == :male && match_gender == :female
         return false if gender == :female && match_gender != :female
 
-        tests.detect { |test| test.match?(name) }
+        !!name.match(@tests_regexp)
       end
 
       # Is this exceptional rule?


### PR DESCRIPTION
Before:

```
Running Petrovich::Benchmark
bench_dative_to_s        0.009390        0.038018        0.151484        0.606973
```

After:

```
Running Petrovich::Benchmark
bench_dative_to_s        0.007309        0.029983        0.116903        0.469428
```

Speed boost around 23%