### PR TITLE
use more strict rule selection for female

### DIFF
--- a/lib/petrovich/case/rule.rb
+++ b/lib/petrovich/case/rule.rb
@@ -24,7 +24,7 @@ module Petrovich
 
         match_gender = match_gender.to_sym.downcase
 
-        return false if gender == :male && match_gender == :female
+        return false if gender != :female && match_gender == :female
         return false if gender == :female && match_gender != :female
 
         !!name.match(@tests_regexp)


### PR DESCRIPTION
Since female last name detection is precise enough to distinct it from male and androgynous, reject androgynous rules when female gender is detected.

Before: 

```
        Ac(nominative|male) = 100.0000%
        Ac(genitive|male) = 99.3527%
        Ac(dative|male) = 99.3527%
        Ac(accusative|male) = 99.3776%
        Ac(instrumental|male) = 98.8934%
        Ac(prepositional|male) = 99.3402%
        Ac(nominative|female) = 100.0000%
        Ac(genitive|female) = 86.2105%
        Ac(dative|female) = 86.2105%
        Ac(accusative|female) = 86.2405%
        Ac(instrumental|female) = 85.7994%
        Ac(prepositional|female) = 86.2105%
Well, the accuracy on 88314 examples is about 94.4165%.
Sum of the 83383 correct examples and 4931 mistakes is 88314.
```

After:

```

        Ac(nominative|male) = 100.0000%
        Ac(genitive|male) = 99.3527%
        Ac(dative|male) = 99.3527%
        Ac(accusative|male) = 99.3776%
        Ac(instrumental|male) = 98.8934%
        Ac(prepositional|male) = 99.3402%
        Ac(nominative|female) = 100.0000%
        Ac(genitive|female) = 99.7006%
        Ac(dative|female) = 99.7006%
        Ac(accusative|female) = 99.7305%
        Ac(instrumental|female) = 99.2252%
        Ac(prepositional|female) = 99.7006%
Well, the accuracy on 88314 examples is about 99.5176%.
Sum of the 87888 correct examples and 426 mistakes is 88314.
```
