### PR TITLE
use more restrictive female lastname search

### DIFF
--- a/lib/petrovich/case/rule.rb
+++ b/lib/petrovich/case/rule.rb
@@ -24,7 +24,7 @@ module Petrovich
 
         match_gender = match_gender.to_sym.downcase
 
-        return false if gender == :male && match_gender == :female
+        return false if gender != :female && match_gender == :female
         return false if gender == :female && match_gender != :female
 
         !!name.match(@tests_regexp)

--- a/lib/petrovich/rule_set.rb
+++ b/lib/petrovich/rule_set.rb
@@ -79,7 +79,8 @@ module Petrovich
     end
 
     def find_case_rule(name, gender, as)
-      @case_rules.find { |rule| rule.match?(name, gender, as) }
+      found_rule = @case_rules.find { |rule| rule.match?(name, gender, as) }
+      found_rule || @case_rules.find { |rule| rule.match?(name, :androgynous, as) }
     end
 
     def find_gender_rule(name, as)

--- a/test/petrovich_test.rb
+++ b/test/petrovich_test.rb
@@ -168,6 +168,14 @@ describe Petrovich do
     assert_equal true, p.gender == :female
   end
 
+  it 'inflects lastname [ая]' do
+    lastname = Petrovich(
+      lastname: 'Слуцкая',
+    ).dative.lastname
+
+    assert_equal 'Слуцкой', lastname
+  end
+
   # Future stuff
   # Petrovich.scan do |p|
   #   name = [p.lastname, p.firstname, p.middlename].join(' ')


### PR DESCRIPTION
Fallback to androgynous only if none found.

```
Well, the accuracy on 88314 examples is about 94.4165%.
Sum of the 83383 correct examples and 4931 mistakes is 88314.
```

=>

```
Well, the accuracy on 88314 examples is about 99.5629%.
Sum of the 87928 correct examples and 386 mistakes is 88314.
```